### PR TITLE
Add session auth, CRUD endpoints, transactions and pagination

### DIFF
--- a/database/fake/fake.go
+++ b/database/fake/fake.go
@@ -4,12 +4,12 @@ import (
 	"context"
 	"errors"
 	"fmt"
-	"github.com/szucik/trade-helper/apperrors"
 	"net/http"
 	"sync"
 
 	"github.com/google/uuid"
 
+	"github.com/szucik/trade-helper/apperrors"
 	"github.com/szucik/trade-helper/transaction"
 	"github.com/szucik/trade-helper/user"
 )
@@ -19,14 +19,9 @@ type userKey struct {
 }
 
 type MemoryRepository struct {
-	users map[userKey]user.Aggregate
-	sync.Mutex
+	users        map[userKey]user.Aggregate
 	transactions map[string]map[string]map[uuid.UUID]transaction.Transaction
-}
-
-func (mr MemoryRepository) GetUserByName(ctx context.Context, userName string) (user.Aggregate, error) {
-	//TODO implement me
-	panic("implement me")
+	sync.Mutex
 }
 
 func NewDatabase() MemoryRepository {
@@ -40,51 +35,26 @@ func (mr MemoryRepository) SignUp(_ context.Context, aggregate user.Aggregate) (
 	mr.Lock()
 	defer mr.Unlock()
 
-	if mr.users == nil {
-		mr.users = make(map[userKey]user.Aggregate)
-	}
-
-	key := userKey{
-		name: aggregate.User().Email,
-	}
+	key := userKey{name: aggregate.User().Email}
 
 	if _, ok := mr.users[key]; ok {
 		return "", apperrors.ErrorResponse{
-			Code:    http.StatusBadRequest,
+			Code:    http.StatusConflict,
 			Message: "user already exists",
 			Type:    "DuplicateUser",
 		}
 	}
 
 	mr.users[key] = aggregate
-
 	return aggregate.User().Username, nil
-}
-
-func (mr MemoryRepository) GetUsers(_ context.Context) ([]user.Aggregate, error) {
-	mr.Lock()
-	defer mr.Unlock()
-
-	var users []user.Aggregate
-	if len(mr.users) > 0 {
-		for _, aggregate := range mr.users {
-			users = append(users, aggregate)
-		}
-	}
-
-	return users, nil
 }
 
 func (mr MemoryRepository) GetUserByEmail(_ context.Context, email string) (user.Aggregate, error) {
 	mr.Lock()
 	defer mr.Unlock()
 
-	key := userKey{
-		name: email,
-	}
-
-	if user, exist := mr.users[key]; exist {
-		return user, nil
+	if a, ok := mr.users[userKey{name: email}]; ok {
+		return a, nil
 	}
 
 	return user.Aggregate{}, apperrors.ErrorResponse{
@@ -94,23 +64,101 @@ func (mr MemoryRepository) GetUserByEmail(_ context.Context, email string) (user
 	}
 }
 
+func (mr MemoryRepository) GetUserByName(_ context.Context, userName string) (user.Aggregate, error) {
+	mr.Lock()
+	defer mr.Unlock()
+
+	for _, a := range mr.users {
+		if a.User().Username == userName {
+			return a, nil
+		}
+	}
+
+	return user.Aggregate{}, apperrors.ErrorResponse{
+		Code:    http.StatusNotFound,
+		Message: "user not found",
+		Type:    "UserNotFound",
+	}
+}
+
+func (mr MemoryRepository) GetUsers(_ context.Context, p user.PaginationIn) ([]user.Aggregate, error) {
+	mr.Lock()
+	defer mr.Unlock()
+
+	all := make([]user.Aggregate, 0, len(mr.users))
+	for _, a := range mr.users {
+		all = append(all, a)
+	}
+
+	if p.Limit <= 0 {
+		return all, nil
+	}
+
+	start := p.Page * p.Limit
+	if start >= len(all) {
+		return nil, nil
+	}
+	end := start + p.Limit
+	if end > len(all) {
+		end = len(all)
+	}
+	return all[start:end], nil
+}
+
 func (mr MemoryRepository) SaveAggregate(_ context.Context, aggregate user.Aggregate) error {
 	mr.Lock()
 	defer mr.Unlock()
 
-	key := userKey{
-		name: aggregate.User().Email,
+	key := userKey{name: aggregate.User().Email}
+	if _, ok := mr.users[key]; !ok {
+		return errors.New("user does not exist")
 	}
-
-	_, exist := mr.users[key]
-	if !exist {
-		return errors.New("user dont exist")
-
-	}
-
 	mr.users[key] = aggregate
-
 	return nil
+}
+
+func (mr MemoryRepository) UpdateUser(_ context.Context, currentUsername string, aggregate user.Aggregate) error {
+	mr.Lock()
+	defer mr.Unlock()
+
+	var oldKey userKey
+	var found bool
+	for k, a := range mr.users {
+		if a.User().Username == currentUsername {
+			oldKey = k
+			found = true
+			break
+		}
+	}
+	if !found {
+		return apperrors.ErrorResponse{
+			Code:    http.StatusNotFound,
+			Message: "user not found",
+			Type:    "UserNotFound",
+		}
+	}
+
+	delete(mr.users, oldKey)
+	mr.users[userKey{name: aggregate.User().Email}] = aggregate
+	return nil
+}
+
+func (mr MemoryRepository) DeleteUser(_ context.Context, username string) error {
+	mr.Lock()
+	defer mr.Unlock()
+
+	for k, a := range mr.users {
+		if a.User().Username == username {
+			delete(mr.users, k)
+			return nil
+		}
+	}
+
+	return apperrors.ErrorResponse{
+		Code:    http.StatusNotFound,
+		Message: "user not found",
+		Type:    "UserNotFound",
+	}
 }
 
 func (mr MemoryRepository) AddTransaction(_ context.Context, vo transaction.ValueObject) (string, error) {
@@ -122,7 +170,6 @@ func (mr MemoryRepository) AddTransaction(_ context.Context, vo transaction.Valu
 	if mr.transactions[t.UserName] == nil {
 		mr.transactions[t.UserName] = make(map[string]map[uuid.UUID]transaction.Transaction)
 	}
-
 	if mr.transactions[t.UserName][t.PortfolioName] == nil {
 		mr.transactions[t.UserName][t.PortfolioName] = make(map[uuid.UUID]transaction.Transaction)
 	}
@@ -131,12 +178,26 @@ func (mr MemoryRepository) AddTransaction(_ context.Context, vo transaction.Valu
 	return fmt.Sprintf("%s: %s", t.Symbol, t.Quantity), nil
 }
 
-func (mr MemoryRepository) UpdateUser(ctx context.Context) (user.Aggregate, error) {
-	// TODO implement me
-	panic("implement me")
-}
+func (mr MemoryRepository) GetTransactions(_ context.Context, username, portfolioName string) ([]transaction.ValueObject, error) {
+	mr.Lock()
+	defer mr.Unlock()
 
-func (mr MemoryRepository) Dashboard(ctx context.Context) (user.Aggregate, error) {
-	// TODO implement me
-	panic("implement me")
+	portfolios, ok := mr.transactions[username]
+	if !ok {
+		return nil, nil
+	}
+	txns, ok := portfolios[portfolioName]
+	if !ok {
+		return nil, nil
+	}
+
+	var result []transaction.ValueObject
+	for _, t := range txns {
+		vo, err := t.NewTransaction()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, vo)
+	}
+	return result, nil
 }

--- a/database/mongo/mongo.go
+++ b/database/mongo/mongo.go
@@ -5,17 +5,16 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/szucik/trade-helper/portfolio"
-	"github.com/szucik/trade-helper/transaction"
-	"github.com/szucik/trade-helper/user"
-	"github.com/szucik/trade-helper/user/document"
 	"go.mongodb.org/mongo-driver/bson"
 	"go.mongodb.org/mongo-driver/bson/primitive"
 	"go.mongodb.org/mongo-driver/mongo"
 	"go.mongodb.org/mongo-driver/mongo/options"
-)
 
-const uri = "mongodb://127.0.0.1:27017/"
+	"github.com/szucik/trade-helper/portfolio"
+	"github.com/szucik/trade-helper/transaction"
+	"github.com/szucik/trade-helper/user"
+	"github.com/szucik/trade-helper/user/document"
+)
 
 type Repository struct {
 	users        *mongo.Collection
@@ -33,100 +32,188 @@ func NewDatabase(ctx context.Context) (Repository, error) {
 		return Repository{}, fmt.Errorf("mongo NewDatabase failed: %w", err)
 	}
 
-	return Repository{
+	r := Repository{
 		users:        db.Collection("users"),
 		transactions: db.Collection("transactions"),
-	}, nil
+	}
+
+	if err := createIndexes(ctx, r); err != nil {
+		return Repository{}, fmt.Errorf("mongo NewDatabase createIndexes failed: %w", err)
+	}
+
+	return r, nil
+}
+
+func createIndexes(ctx context.Context, r Repository) error {
+	_, err := r.users.Indexes().CreateMany(ctx, []mongo.IndexModel{
+		{
+			Keys:    bson.D{{Key: "user.email", Value: 1}},
+			Options: options.Index().SetUnique(true).SetName("unique_email"),
+		},
+		{
+			Keys:    bson.D{{Key: "user.username", Value: 1}},
+			Options: options.Index().SetUnique(true).SetName("unique_username"),
+		},
+	})
+	return err
 }
 
 func (r Repository) SignUp(ctx context.Context, aggregate user.Aggregate) (string, error) {
-	document := document.NewDocument(aggregate)
-
-	_, err := r.users.InsertOne(ctx, document)
+	doc := document.NewDocument(aggregate)
+	_, err := r.users.InsertOne(ctx, doc)
 	if err != nil {
 		return "", err
 	}
-
 	return aggregate.User().Email, nil
 }
 
 func (r Repository) GetUserByName(ctx context.Context, userName string) (user.Aggregate, error) {
 	var result Document
-	filter := bson.M{"username": userName}
-	err := r.users.FindOne(ctx, filter).Decode(&result)
-	if err != nil {
+	filter := bson.D{{Key: "user.username", Value: userName}}
+	if err := r.users.FindOne(ctx, filter).Decode(&result); err != nil {
 		return user.Aggregate{}, err
 	}
-
-	aggregate, err := result.User.NewAggregate()
-	if err != nil {
-		return user.Aggregate{}, err
-	}
-	return aggregate, nil
+	return result.toAggregate()
 }
 
 func (r Repository) GetUserByEmail(ctx context.Context, email string) (user.Aggregate, error) {
 	var result Document
 	filter := bson.D{{Key: "user.email", Value: email}}
-
-	err := r.users.FindOne(ctx, filter).Decode(&result)
-	if err != nil {
+	if err := r.users.FindOne(ctx, filter).Decode(&result); err != nil {
 		return user.Aggregate{}, err
 	}
-
-	aggregate, err := result.User.NewAggregate()
-	if err != nil {
-		return user.Aggregate{}, err
-	}
-	return aggregate, nil
+	return result.toAggregate()
 }
 
-func (r Repository) GetUsers(ctx context.Context) ([]user.Aggregate, error) {
-	cursor, err := r.users.Find(ctx, bson.D{})
+func (r Repository) GetUsers(ctx context.Context, p user.PaginationIn) ([]user.Aggregate, error) {
+	opts := options.Find()
+	if p.Limit > 0 {
+		opts.SetSkip(int64(p.Page * p.Limit))
+		opts.SetLimit(int64(p.Limit))
+	}
+
+	cursor, err := r.users.Find(ctx, bson.D{}, opts)
 	if err != nil {
 		return nil, fmt.Errorf("GetUsers failed: %w", err)
 	}
-	var results []user.Aggregate
-	if err = cursor.All(ctx, &results); err != nil {
+
+	var docs []Document
+	if err = cursor.All(ctx, &docs); err != nil {
 		return nil, fmt.Errorf("GetUsers failed: %w", err)
 	}
-	return results, nil
+
+	aggregates := make([]user.Aggregate, 0, len(docs))
+	for _, doc := range docs {
+		a, err := doc.toAggregate()
+		if err != nil {
+			return nil, fmt.Errorf("GetUsers failed: %w", err)
+		}
+		aggregates = append(aggregates, a)
+	}
+	return aggregates, nil
 }
 
 func (r Repository) SaveAggregate(ctx context.Context, aggregate user.Aggregate) error {
-	_, err := r.users.InsertOne(ctx, aggregate)
+	doc := document.NewDocument(aggregate)
+	filter := bson.D{{Key: "user.email", Value: aggregate.User().Email}}
+	_, err := r.users.ReplaceOne(ctx, filter, doc)
 	if err != nil {
 		return fmt.Errorf("SaveAggregate failed: %w", err)
 	}
 	return nil
 }
 
-func (r Repository) AddTransaction(ctx context.Context, transaction transaction.ValueObject) (string, error) {
-	res, err := r.transactions.InsertOne(ctx, transaction)
+func (r Repository) UpdateUser(ctx context.Context, currentUsername string, aggregate user.Aggregate) error {
+	doc := document.NewDocument(aggregate)
+	filter := bson.D{{Key: "user.username", Value: currentUsername}}
+	_, err := r.users.ReplaceOne(ctx, filter, doc)
+	if err != nil {
+		return fmt.Errorf("UpdateUser failed: %w", err)
+	}
+	return nil
+}
+
+func (r Repository) DeleteUser(ctx context.Context, username string) error {
+	filter := bson.D{{Key: "user.username", Value: username}}
+	res, err := r.users.DeleteOne(ctx, filter)
+	if err != nil {
+		return fmt.Errorf("DeleteUser failed: %w", err)
+	}
+	if res.DeletedCount == 0 {
+		return fmt.Errorf("DeleteUser: user %q not found", username)
+	}
+	return nil
+}
+
+func (r Repository) AddTransaction(ctx context.Context, vo transaction.ValueObject) (string, error) {
+	t := vo.Transaction()
+	res, err := r.transactions.InsertOne(ctx, t)
 	if err != nil {
 		return "", fmt.Errorf("AddTransaction failed: %w", err)
 	}
 	return res.InsertedID.(primitive.ObjectID).Hex(), nil
 }
 
+func (r Repository) GetTransactions(ctx context.Context, username, portfolioName string) ([]transaction.ValueObject, error) {
+	filter := bson.D{
+		{Key: "username", Value: username},
+		{Key: "portfolio_name", Value: portfolioName},
+	}
+	cursor, err := r.transactions.Find(ctx, filter)
+	if err != nil {
+		return nil, fmt.Errorf("GetTransactions failed: %w", err)
+	}
+
+	var txns []transaction.Transaction
+	if err = cursor.All(ctx, &txns); err != nil {
+		return nil, fmt.Errorf("GetTransactions decode failed: %w", err)
+	}
+
+	result := make([]transaction.ValueObject, 0, len(txns))
+	for _, t := range txns {
+		vo, err := t.NewTransaction()
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, vo)
+	}
+	return result, nil
+}
+
+func (d Document) toAggregate() (user.Aggregate, error) {
+	aggregate, err := d.User.NewAggregate()
+	if err != nil {
+		return user.Aggregate{}, err
+	}
+	for _, p := range d.Portfolios {
+		if err := aggregate.AddPortfolio(p); err != nil {
+			return user.Aggregate{}, err
+		}
+	}
+	return aggregate, nil
+}
+
 func connectWithMongoDB(ctx context.Context) (*mongo.Database, error) {
+	mongoURI := os.Getenv("MONGO_URI")
+	if mongoURI == "" {
+		mongoURI = "mongodb://127.0.0.1:27017/"
+	}
 	serverAPI := options.ServerAPI(options.ServerAPIVersion1)
-	opts := options.Client().ApplyURI(uri).SetServerAPIOptions(serverAPI)
+	opts := options.Client().ApplyURI(mongoURI).SetServerAPIOptions(serverAPI)
 
 	client, err := mongo.Connect(ctx, opts)
 	if err != nil {
 		return nil, fmt.Errorf("connection with Mongo failed: %w", err)
 	}
 
-	// Ping the database to confirm a successful connection
-	err = client.Ping(ctx, nil)
-	if err != nil {
+	if err = client.Ping(ctx, nil); err != nil {
 		return nil, fmt.Errorf("ping to Mongo failed: %w", err)
 	}
 
 	fmt.Println("Successfully connected to MongoDB!")
-	dbName := os.Getenv("MONGO_DB_NAME")
-	db := client.Database(dbName)
-
-	return db, nil
+	dbName := os.Getenv("MONGO_DB")
+	if dbName == "" {
+		dbName = "tradehelper"
+	}
+	return client.Database(dbName), nil
 }

--- a/main.go
+++ b/main.go
@@ -6,27 +6,34 @@ import (
 	"net/http"
 	"os"
 	"os/signal"
+	"syscall"
 	"time"
-
-	"github.com/szucik/trade-helper/web"
 
 	gohandlers "github.com/gorilla/handlers"
 	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
 
 	"github.com/szucik/trade-helper/database/mongo"
 	"github.com/szucik/trade-helper/user"
+	"github.com/szucik/trade-helper/web"
 	"github.com/szucik/trade-helper/web/handlers"
 )
 
 func main() {
-	ctx, stop := context.WithTimeout(context.Background(), 30*time.Second)
-	defer stop()
+	connectCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancel()
 
-	logger := log.New(os.Stdout, "logger", log.LstdFlags)
-	database, err := mongo.NewDatabase(ctx)
+	logger := log.New(os.Stdout, "logger ", log.LstdFlags)
+	database, err := mongo.NewDatabase(connectCtx)
 	if err != nil {
 		panic(err)
 	}
+
+	sessionSecret := os.Getenv("SESSION_SECRET")
+	if sessionSecret == "" {
+		log.Fatal("SESSION_SECRET environment variable is required")
+	}
+	store := sessions.NewCookieStore([]byte(sessionSecret))
 
 	users := user.Users{
 		Logger:       logger,
@@ -35,34 +42,25 @@ func main() {
 	}
 
 	sm := mux.NewRouter()
-	sm.Use(web.MiddlewareIsAuth)
+	sm.Use(web.MiddlewareIsAuth(store))
 
-	// Post
 	postRouter := sm.Methods(http.MethodPost).Subrouter()
 	postRouter.HandleFunc("/signup", handlers.SignUp(users))
-	postRouter.HandleFunc("/signin", handlers.SignIn(users))
-	postRouter.HandleFunc(
-		"/users/{username:[a-z, A-Z, 0-9]+}/portfolio", handlers.AddPortfolio(ctx, users))
-	postRouter.HandleFunc(
-		"/users/{username:[a-z, A-Z, 0-9]+}/portfolio/{name:[a-z, A-Z, 0-9]+}/transactions",
-		handlers.AddTransaction(ctx, users),
-	)
-	// postRouter.Use(users.MiddlewareUserValid)
+	postRouter.HandleFunc("/signin", handlers.SignIn(users, store))
+	postRouter.HandleFunc("/users/{username:[a-zA-Z0-9]+}/portfolio", handlers.AddPortfolio(users))
+	postRouter.HandleFunc("/users/{username:[a-zA-Z0-9]+}/portfolio/{name:[a-zA-Z0-9]+}/transactions", handlers.AddTransaction(users))
 
-	// Users
 	getRouter := sm.Methods(http.MethodGet).Subrouter()
 	getRouter.HandleFunc("/users", handlers.GetUsers(users))
-	getRouter.HandleFunc("/users/{username:[a-z, A-Z, 0-9]+}", handlers.GetUser(users))
-	//getRouter.HandleFunc("/users/{email:[a-z, A-Z, 0-9]+}", handlers.GetUser( users))
+	getRouter.HandleFunc("/users/{username:[a-zA-Z0-9]+}", handlers.GetUser(users))
+	getRouter.HandleFunc("/users/{username:[a-zA-Z0-9]+}/portfolio/{name:[a-zA-Z0-9]+}/transactions", handlers.GetTransactions(users))
 
-	// putRouter := sm.Methods(http.MethodPut).Subrouter()
-	// putRouter.HandleFunc("/users/{id:[0-9]+}", users.UpdateUser)
-	// putRouter.Use(users.MiddlewareUserValid)
+	putRouter := sm.Methods(http.MethodPut).Subrouter()
+	putRouter.HandleFunc("/users/{username:[a-zA-Z0-9]+}", handlers.UpdateUser(users))
 
-	// deleteRouter := sm.Methods(http.MethodDelete).Subrouter()
-	// deleteRouter.HandleFunc("/users/{id:[0-9]+}", users.DeleteUser)
+	deleteRouter := sm.Methods(http.MethodDelete).Subrouter()
+	deleteRouter.HandleFunc("/users/{username:[a-zA-Z0-9]+}", handlers.DeleteUser(users))
 
-	// CORS
 	ch := gohandlers.CORS(gohandlers.AllowedOrigins([]string{"localhost:3000"}))
 
 	s := &http.Server{
@@ -75,23 +73,17 @@ func main() {
 
 	go func() {
 		log.Println("Starting server on port 9090")
-
-		err = s.ListenAndServe()
-		if err != nil {
+		if err := s.ListenAndServe(); err != nil && err != http.ErrServerClosed {
 			log.Fatal(err)
-			os.Exit(1)
 		}
 	}()
 
-	// trap sigterm or interupt and gracefully shutdown the server
 	c := make(chan os.Signal, 1)
-	signal.Notify(c, os.Interrupt)
-	signal.Notify(c, os.Kill)
-
-	// Block until a signal is received.
+	signal.Notify(c, os.Interrupt, syscall.SIGTERM)
 	sig := <-c
 	log.Println("Got signal:", sig)
 
-	// gracefully shutdown the server, waiting max 30 seconds for current operations to complete
-	s.Shutdown(ctx)
+	shutdownCtx, shutdownCancel := context.WithTimeout(context.Background(), 30*time.Second)
+	defer shutdownCancel()
+	s.Shutdown(shutdownCtx)
 }

--- a/portfolio/portfolio_test.go
+++ b/portfolio/portfolio_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/shopspring/decimal"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
 	"github.com/szucik/trade-helper/clock"
@@ -29,7 +30,7 @@ func (p Portfolio) WithName(name string) Portfolio {
 }
 
 func TestPortfolio_NewPortfolio(t *testing.T) {
-	t.Run("should return an error when portfolio name", func(t *testing.T) {
+	t.Run("should return an error when portfolio name ", func(t *testing.T) {
 		testCases := map[string]struct {
 			p Portfolio
 		}{
@@ -38,6 +39,9 @@ func TestPortfolio_NewPortfolio(t *testing.T) {
 			},
 			"has unauthorized signs": {
 				p: portfolio.WithName("name123$!-+ "),
+			},
+			"contains only spaces": {
+				p: portfolio.WithName("   "),
 			},
 		}
 
@@ -49,5 +53,11 @@ func TestPortfolio_NewPortfolio(t *testing.T) {
 				require.Error(t, err)
 			})
 		}
+	})
+
+	t.Run("should create portfolio when name is valid", func(t *testing.T) {
+		entity, err := pto.Portfolio(portfolio).NewPortfolio()
+		require.NoError(t, err)
+		assert.Equal(t, portfolio.Name, entity.Portfolio().Name)
 	})
 }

--- a/transaction/transaction.go
+++ b/transaction/transaction.go
@@ -12,14 +12,29 @@ import (
 
 var emptyFieldErr = errors.New("this field must not be empty")
 
+type TransactionType int
+
+const (
+	Buy  TransactionType = iota
+	Sell TransactionType = iota
+)
+
+func (t TransactionType) String() string {
+	if t == Sell {
+		return "sell"
+	}
+	return "buy"
+}
+
 type Transaction struct {
-	ID            uuid.UUID       `json:"id"`
-	UserName      string          `json:"user_id" validate:"required"`
-	PortfolioName string          `json:"portfolio_id" validate:"required"`
-	Symbol        string          `json:"symbol" validate:"required"`
-	Quantity      decimal.Decimal `json:"quantity" validate:"required"`
-	Price         decimal.Decimal `json:"price" validate:"required"`
-	Created       time.Time       `json:"created"`
+	ID            uuid.UUID       `json:"id"           bson:"id"`
+	UserName      string          `json:"user_id"      bson:"username"`
+	PortfolioName string          `json:"portfolio_id" bson:"portfolio_name"`
+	Symbol        string          `json:"symbol"       bson:"symbol"`
+	Type          TransactionType `json:"type"         bson:"type"`
+	Quantity      decimal.Decimal `json:"quantity"     bson:"quantity"`
+	Price         decimal.Decimal `json:"price"        bson:"price"`
+	Created       time.Time       `json:"created"      bson:"created"`
 }
 
 type ValueObject struct {

--- a/transaction/transaction_test.go
+++ b/transaction/transaction_test.go
@@ -43,6 +43,18 @@ func TestTransaction_NewTransaction(t *testing.T) {
 			"quantity is less than or equal to zero": {
 				instance: instance.WithQuantity(decimal.New(0, 0)),
 			},
+			"quantity is negative": {
+				instance: instance.WithQuantity(decimal.New(-1, 0)),
+			},
+			"userName contains only spaces": {
+				instance: instance.WithUserName("   "),
+			},
+			"symbol contains only spaces": {
+				instance: instance.WithSymbol("   "),
+			},
+			"portfolioName contains only spaces": {
+				instance: instance.WithPortfolioName("   "),
+			},
 		}
 
 		for name, testCase := range testCases {

--- a/user/aggregate.go
+++ b/user/aggregate.go
@@ -3,6 +3,7 @@ package user
 import (
 	"errors"
 	"fmt"
+	"github.com/shopspring/decimal"
 	"github.com/szucik/trade-helper/portfolio"
 	"math/rand"
 )
@@ -43,6 +44,22 @@ func (a *Aggregate) AddPortfolio(entity portfolio.Entity) error {
 	a.portfolios = append(a.portfolios, entity)
 
 	return nil
+}
+
+func (a *Aggregate) UpdatePortfolioTotalCost(name string, delta decimal.Decimal) error {
+	for i, p := range a.portfolios {
+		pto := p.Portfolio()
+		if pto.Name == name {
+			pto.TotalCost = pto.TotalCost.Add(delta)
+			entity, err := pto.NewPortfolio()
+			if err != nil {
+				return fmt.Errorf("UpdatePortfolioTotalCost: %w", err)
+			}
+			a.portfolios[i] = entity
+			return nil
+		}
+	}
+	return errors.New("portfolio not found")
 }
 
 func (a *Aggregate) FindPortfolio(name string) (portfolio.Portfolio, error) {

--- a/user/aggregate_test.go
+++ b/user/aggregate_test.go
@@ -1,13 +1,14 @@
 package user_test
 
 import (
+	"testing"
+
 	"github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"github.com/szucik/trade-helper/clock"
 	pto "github.com/szucik/trade-helper/portfolio"
 	"github.com/szucik/trade-helper/user"
-	"testing"
 )
 
 var (
@@ -46,6 +47,49 @@ func TestPortfolio_AddPortfolio(t *testing.T) {
 		// then
 		name := instanceAggregate.Portfolios()[0].Portfolio().Name
 		assert.Equal(t, name, portfolio.Name)
+	})
+}
+
+func TestPortfolio_AddPortfolio_DuplicateName(t *testing.T) {
+	aggregate, err := user.User(testUser).NewAggregate()
+	require.NoError(t, err)
+
+	err = aggregate.AddPortfolio(instancePortfolio)
+	require.NoError(t, err)
+
+	t.Run("should return error when portfolio with same name already exists", func(t *testing.T) {
+		err := aggregate.AddPortfolio(instancePortfolio)
+		require.Error(t, err)
+	})
+}
+
+func TestAggregate_UpdatePortfolioTotalCost(t *testing.T) {
+	aggregate, err := user.User(testUser).NewAggregate()
+	require.NoError(t, err)
+
+	p, _ := pto.Portfolio{Name: "wallet", Created: clock.FakeTime()}.NewPortfolio()
+	require.NoError(t, aggregate.AddPortfolio(p))
+
+	t.Run("should update TotalCost by delta", func(t *testing.T) {
+		delta := decimal.NewFromFloat(300.00)
+		err := aggregate.UpdatePortfolioTotalCost("wallet", delta)
+		require.NoError(t, err)
+		updated, err := aggregate.FindPortfolio("wallet")
+		require.NoError(t, err)
+		assert.True(t, updated.TotalCost.Equal(delta))
+	})
+
+	t.Run("should accumulate TotalCost across multiple updates", func(t *testing.T) {
+		err := aggregate.UpdatePortfolioTotalCost("wallet", decimal.NewFromFloat(100.00))
+		require.NoError(t, err)
+		updated, err := aggregate.FindPortfolio("wallet")
+		require.NoError(t, err)
+		assert.True(t, updated.TotalCost.Equal(decimal.NewFromFloat(400.00)))
+	})
+
+	t.Run("should return error when portfolio does not exist", func(t *testing.T) {
+		err := aggregate.UpdatePortfolioTotalCost("nonexistent", decimal.NewFromFloat(100.00))
+		require.Error(t, err)
 	})
 }
 

--- a/user/document/document.go
+++ b/user/document/document.go
@@ -18,9 +18,14 @@ func NewDocument(aggregate user.Aggregate) Document {
 }
 
 func (d *Document) NewAggregate() (user.Aggregate, error) {
-	aggregate, err := d.NewAggregate()
+	aggregate, err := d.User.NewAggregate()
 	if err != nil {
 		return user.Aggregate{}, err
+	}
+	for _, p := range d.Portfolios {
+		if err := aggregate.AddPortfolio(p); err != nil {
+			return user.Aggregate{}, err
+		}
 	}
 	return aggregate, nil
 }

--- a/user/service.go
+++ b/user/service.go
@@ -3,11 +3,11 @@ package user
 import (
 	"context"
 	"fmt"
-	"github.com/google/uuid"
-	"github.com/gorilla/sessions"
 	"log"
 	"time"
 
+	"github.com/google/uuid"
+	"github.com/gorilla/sessions"
 	"github.com/shopspring/decimal"
 	"golang.org/x/crypto/bcrypt"
 
@@ -20,20 +20,24 @@ type UsersService interface {
 	SignIn(ctx context.Context, credentials AuthCredentials) (username string, err error)
 	GetUserByEmail(ctx context.Context, email string) (UserResponse, error)
 	GetUserByName(ctx context.Context, name string) (UserResponse, error)
-	GetUsers(ctx context.Context) (UsersOut, error)
+	GetUsers(ctx context.Context, p PaginationIn) (UsersOut, error)
+	GetTransactions(ctx context.Context, username, portfolioName string) (TransactionsOut, error)
 	AddPortfolio(ctx context.Context, in PortfolioIn) (string, error)
 	AddTransaction(ctx context.Context, in TransactionIn) (string, error)
+	UpdateUser(ctx context.Context, currentUsername string, in UpdateUserIn) (string, error)
+	DeleteUser(ctx context.Context, username string) error
 }
 
 type Repository interface {
-	// GetUserByEmail Dashboard(ctx context.Context) (Aggregate, error)
-	// SignIn(ctx context.Context) (Aggregate, error)
 	GetUserByEmail(ctx context.Context, email string) (Aggregate, error)
 	GetUserByName(ctx context.Context, userName string) (Aggregate, error)
-	GetUsers(ctx context.Context) ([]Aggregate, error)
+	GetUsers(ctx context.Context, p PaginationIn) ([]Aggregate, error)
 	SignUp(ctx context.Context, aggregate Aggregate) (string, error)
 	SaveAggregate(ctx context.Context, aggregate Aggregate) error
-	AddTransaction(ctx context.Context, transaction transaction.ValueObject) (string, error)
+	AddTransaction(ctx context.Context, t transaction.ValueObject) (string, error)
+	GetTransactions(ctx context.Context, username, portfolioName string) ([]transaction.ValueObject, error)
+	UpdateUser(ctx context.Context, currentUsername string, aggregate Aggregate) error
+	DeleteUser(ctx context.Context, username string) error
 }
 
 type Users struct {
@@ -54,10 +58,14 @@ type TransactionIn struct {
 	Symbol        string `json:"symbol"`
 	Amount        string `json:"amount"`
 	Quantity      string `json:"quantity"`
+	Type          string `json:"type"`
 }
 
 type UsersOut struct {
-	Users []UserResponse
+	Users []UserResponse `json:"users"`
+	Total int            `json:"total"`
+	Page  int            `json:"page"`
+	Limit int            `json:"limit"`
 }
 
 func (u Users) SignUp(ctx context.Context, user User) (string, error) {
@@ -69,16 +77,17 @@ func (u Users) SignUp(ctx context.Context, user User) (string, error) {
 		return "", err
 	}
 
-	err = aggregate.hashPassword()
-	if err != nil {
+	if err = aggregate.hashPassword(); err != nil {
 		return "", err
 	}
 
 	id, err := u.Database.SignUp(ctx, aggregate)
 	if err != nil {
+		u.Logger.Printf("SignUp failed for %s: %v", user.Email, err)
 		return "", fmt.Errorf("database.SignUp failed: %w", err)
 	}
 
+	u.Logger.Printf("SignUp: new user %s", user.Username)
 	return id, nil
 }
 
@@ -87,7 +96,6 @@ func (u Users) GetUserByName(ctx context.Context, username string) (UserResponse
 	if err != nil {
 		return UserResponse{}, fmt.Errorf("database.GetUserByName failed: %w", err)
 	}
-
 	return transformToUserResponse(aggregate), nil
 }
 
@@ -96,23 +104,41 @@ func (u Users) GetUserByEmail(ctx context.Context, email string) (UserResponse, 
 	if err != nil {
 		return UserResponse{}, fmt.Errorf("database.GetUserByEmail failed: %w", err)
 	}
-
 	return transformToUserResponse(aggregate), nil
 }
 
-func (u Users) GetUsers(ctx context.Context) (UsersOut, error) {
-	var response UsersOut
-
-	users, err := u.Database.GetUsers(ctx)
+func (u Users) GetUsers(ctx context.Context, p PaginationIn) (UsersOut, error) {
+	aggregates, err := u.Database.GetUsers(ctx, p)
 	if err != nil {
 		return UsersOut{}, fmt.Errorf("database.GetUsers failed: %w", err)
 	}
 
-	for _, user := range users {
-		response.Users = append(response.Users, transformToUserResponse(user))
+	out := UsersOut{Page: p.Page, Limit: p.Limit, Total: len(aggregates)}
+	for _, a := range aggregates {
+		out.Users = append(out.Users, transformToUserResponse(a))
+	}
+	return out, nil
+}
+
+func (u Users) GetTransactions(ctx context.Context, username, portfolioName string) (TransactionsOut, error) {
+	vos, err := u.Database.GetTransactions(ctx, username, portfolioName)
+	if err != nil {
+		return TransactionsOut{}, fmt.Errorf("database.GetTransactions failed: %w", err)
 	}
 
-	return response, nil
+	var out TransactionsOut
+	for _, vo := range vos {
+		t := vo.Transaction()
+		out.Transactions = append(out.Transactions, TransactionResponse{
+			ID:       t.ID.String(),
+			Symbol:   t.Symbol,
+			Type:     t.Type,
+			Quantity: t.Quantity,
+			Price:    t.Price,
+			Created:  t.Created,
+		})
+	}
+	return out, nil
 }
 
 func (u Users) AddPortfolio(ctx context.Context, in PortfolioIn) (name string, _ error) {
@@ -129,50 +155,51 @@ func (u Users) AddPortfolio(ctx context.Context, in PortfolioIn) (name string, _
 		ProfitLossDay:   decimal.NewFromInt(0),
 		Created:         time.Now(),
 	}.NewPortfolio()
-
 	if err != nil {
 		return "", fmt.Errorf("portfolio.NewPortfolio failed: %w", err)
 	}
 
-	err = aggregate.AddPortfolio(entity)
-	if err != nil {
+	if err = aggregate.AddPortfolio(entity); err != nil {
 		return "", fmt.Errorf("aggregate.AddPortfolio failed: %w", err)
 	}
 
-	err = u.Database.SaveAggregate(ctx, aggregate)
-	if err != nil {
+	if err = u.Database.SaveAggregate(ctx, aggregate); err != nil {
+		u.Logger.Printf("AddPortfolio SaveAggregate failed for %s: %v", in.UserName, err)
 		return "", fmt.Errorf("aggregate.SaveAggregate failed: %w", err)
 	}
 
+	u.Logger.Printf("AddPortfolio: user %s added portfolio %s", in.UserName, in.Name)
 	return entity.Portfolio().Name, nil
 }
 
 func (u Users) AddTransaction(ctx context.Context, in TransactionIn) (string, error) {
-	aggregate, err := u.Database.GetUserByEmail(ctx, in.UserName)
+	aggregate, err := u.Database.GetUserByName(ctx, in.UserName)
 	if err != nil {
 		return "", fmt.Errorf("service.AddTransaction: %w", err)
 	}
 
-	_, err = aggregate.FindPortfolio(in.PortfolioName)
-	if err != nil {
+	if _, err = aggregate.FindPortfolio(in.PortfolioName); err != nil {
 		return "", fmt.Errorf("service.AddTransaction: %w", err)
 	}
 
 	quantity, err := decimal.NewFromString(in.Quantity)
 	if err != nil {
-		return "", fmt.Errorf("service.AddTransaction: %w", err)
+		return "", fmt.Errorf("service.AddTransaction invalid quantity: %w", err)
 	}
 
 	price, err := decimal.NewFromString(in.Amount)
 	if err != nil {
-		return "", fmt.Errorf("service.AddTransaction: %w", err)
+		return "", fmt.Errorf("service.AddTransaction invalid amount: %w", err)
 	}
+
+	txType := parseTransactionType(in.Type)
 
 	t, err := transaction.Transaction{
 		ID:            uuid.New(),
 		UserName:      in.UserName,
 		PortfolioName: in.PortfolioName,
 		Symbol:        in.Symbol,
+		Type:          txType,
 		Created:       time.Now(),
 		Quantity:      quantity,
 		Price:         price,
@@ -182,24 +209,94 @@ func (u Users) AddTransaction(ctx context.Context, in TransactionIn) (string, er
 	}
 
 	id, err := u.Database.AddTransaction(ctx, t)
-
 	if err != nil {
+		u.Logger.Printf("AddTransaction DB failed for %s/%s: %v", in.UserName, in.PortfolioName, err)
 		return "", fmt.Errorf("Database.AddTransaction: %w", err)
 	}
+
+	costDelta := quantity.Mul(price)
+	if txType == transaction.Sell {
+		costDelta = costDelta.Neg()
+	}
+
+	if err := aggregate.UpdatePortfolioTotalCost(in.PortfolioName, costDelta); err != nil {
+		return "", fmt.Errorf("service.AddTransaction: %w", err)
+	}
+
+	if err := u.Database.SaveAggregate(ctx, aggregate); err != nil {
+		u.Logger.Printf("AddTransaction SaveAggregate failed for %s: %v", in.UserName, err)
+		return "", fmt.Errorf("service.AddTransaction SaveAggregate: %w", err)
+	}
+
+	u.Logger.Printf("AddTransaction: %s %s %s x%s", txType, in.Symbol, in.PortfolioName, in.Quantity)
 	return id, nil
 }
 
-func (u Users) SignIn(ctx context.Context, auth AuthCredentials) (username string, err error) {
+func (u Users) SignIn(ctx context.Context, auth AuthCredentials) (string, error) {
 	aggregate, err := u.Database.GetUserByEmail(ctx, auth.Email)
 	if err != nil {
-		return username, fmt.Errorf("service.SignIn: %w", err)
+		return "", fmt.Errorf("service.SignIn: %w", err)
 	}
-	user := aggregate.User()
-	err = compareHashAndPassword(user.Password, auth.Password)
+	usr := aggregate.User()
+	if err = compareHashAndPassword(usr.Password, auth.Password); err != nil {
+		return "", err
+	}
+	u.Logger.Printf("SignIn: user %s authenticated", usr.Username)
+	return usr.Username, nil
+}
+
+func (u Users) UpdateUser(ctx context.Context, currentUsername string, in UpdateUserIn) (string, error) {
+	aggregate, err := u.Database.GetUserByName(ctx, currentUsername)
 	if err != nil {
-		return username, err
+		return "", fmt.Errorf("service.UpdateUser: %w", err)
 	}
-	return user.Username, nil
+
+	current := aggregate.User()
+	if in.Username != "" {
+		current.Username = in.Username
+	}
+	if in.Email != "" {
+		current.Email = in.Email
+	}
+	if in.Password != "" {
+		current.Password = in.Password
+	}
+	current.Updated = time.Now()
+
+	updated, err := u.NewAggregate(current)
+	if err != nil {
+		return "", fmt.Errorf("service.UpdateUser: %w", err)
+	}
+
+	if in.Password != "" {
+		if err := updated.hashPassword(); err != nil {
+			return "", fmt.Errorf("service.UpdateUser: %w", err)
+		}
+	}
+
+	if err := u.Database.UpdateUser(ctx, currentUsername, updated); err != nil {
+		u.Logger.Printf("UpdateUser failed for %s: %v", currentUsername, err)
+		return "", fmt.Errorf("service.UpdateUser: %w", err)
+	}
+
+	u.Logger.Printf("UpdateUser: %s updated", currentUsername)
+	return updated.User().Username, nil
+}
+
+func (u Users) DeleteUser(ctx context.Context, username string) error {
+	if err := u.Database.DeleteUser(ctx, username); err != nil {
+		u.Logger.Printf("DeleteUser failed for %s: %v", username, err)
+		return fmt.Errorf("service.DeleteUser: %w", err)
+	}
+	u.Logger.Printf("DeleteUser: user %s deleted", username)
+	return nil
+}
+
+func parseTransactionType(s string) transaction.TransactionType {
+	if s == "sell" {
+		return transaction.Sell
+	}
+	return transaction.Buy
 }
 
 func hashPassword(password string) (string, error) {
@@ -208,16 +305,14 @@ func hashPassword(password string) (string, error) {
 }
 
 func compareHashAndPassword(hashedPassword, password string) error {
-	err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password))
-	if err != nil {
+	if err := bcrypt.CompareHashAndPassword([]byte(hashedPassword), []byte(password)); err != nil {
 		return fmt.Errorf("compareHashAndPassword: %w", err)
 	}
-
 	return nil
 }
 
 func transformToUserResponse(aggregate Aggregate) UserResponse {
-	user := aggregate.User()
+	usr := aggregate.User()
 
 	var portfolios []portfolio.Portfolio
 	for _, entity := range aggregate.Portfolios() {
@@ -225,9 +320,9 @@ func transformToUserResponse(aggregate Aggregate) UserResponse {
 	}
 
 	return UserResponse{
-		Username:  user.Username,
-		Email:     user.Email,
-		Created:   user.Created,
+		Username:  usr.Username,
+		Email:     usr.Email,
+		Created:   usr.Created,
 		Portfolio: portfolios,
 	}
 }

--- a/user/service_test.go
+++ b/user/service_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"testing"
 
+	shopspring "github.com/shopspring/decimal"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
@@ -26,10 +27,24 @@ var (
 func TestUserService_SignUp(t *testing.T) {
 	t.Run("should return userName when user creation is complete", func(t *testing.T) {
 		// when
-		username, err := userService.SignUp(nil, user.User(testUser))
+		username, err := userService.SignUp(ctx, user.User(testUser))
 		assert.NoError(t, err)
 		// then
 		assert.Equal(t, instanceAggregate.User().Username, username)
+	})
+
+	t.Run("should return error when user with same email already exists", func(t *testing.T) {
+		db := fake.NewDatabase()
+		svc := user.Users{
+			Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+			Database:     &db,
+			NewAggregate: user.User.NewAggregate,
+		}
+		_, err := svc.SignUp(ctx, user.User(testUser))
+		require.NoError(t, err)
+
+		_, err = svc.SignUp(ctx, user.User(testUser))
+		require.Error(t, err)
 	})
 }
 
@@ -37,18 +52,373 @@ func TestUserService_GetUsers(t *testing.T) {
 	t.Run("should return list of users", func(t *testing.T) {
 		databaseWithThreeUserInstances(t)
 
-		// when
-		out, err := userService.GetUsers(ctx)
+		out, err := userService.GetUsers(ctx, user.PaginationIn{})
 		require.NoError(t, err)
-		// then
 		assert.Len(t, out.Users, 3, "Three user instances")
+		assert.Equal(t, 3, out.Total)
+	})
+
+	t.Run("should return paginated list of users", func(t *testing.T) {
+		databaseWithThreeUserInstances(t)
+
+		out, err := userService.GetUsers(ctx, user.PaginationIn{Page: 0, Limit: 2})
+		require.NoError(t, err)
+		assert.Len(t, out.Users, 2)
+	})
+}
+
+func TestUserService_SignIn(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+
+	t.Run("should return username when credentials are valid", func(t *testing.T) {
+		username, err := svc.SignIn(ctx, user.AuthCredentials{
+			Email:    testUser.Email,
+			Password: testUser.Password,
+		})
+		require.NoError(t, err)
+		assert.Equal(t, testUser.Username, username)
+	})
+
+	t.Run("should return error when password is wrong", func(t *testing.T) {
+		_, err := svc.SignIn(ctx, user.AuthCredentials{
+			Email:    testUser.Email,
+			Password: "wrongpassword",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when user does not exist", func(t *testing.T) {
+		_, err := svc.SignIn(ctx, user.AuthCredentials{
+			Email:    "nonexistent@test.com",
+			Password: testUser.Password,
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestUserService_GetUserByEmail(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+
+	t.Run("should return user when email exists", func(t *testing.T) {
+		response, err := svc.GetUserByEmail(ctx, testUser.Email)
+		require.NoError(t, err)
+		assert.Equal(t, testUser.Username, response.Username)
+		assert.Equal(t, testUser.Email, response.Email)
+	})
+
+	t.Run("should return error when email does not exist", func(t *testing.T) {
+		_, err := svc.GetUserByEmail(ctx, "nonexistent@test.com")
+		require.Error(t, err)
+	})
+}
+
+func TestUserService_GetUserByName(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+
+	t.Run("should return user when username exists", func(t *testing.T) {
+		response, err := svc.GetUserByName(ctx, testUser.Username)
+		require.NoError(t, err)
+		assert.Equal(t, testUser.Username, response.Username)
+		assert.Equal(t, testUser.Email, response.Email)
+	})
+
+	t.Run("should return error when username does not exist", func(t *testing.T) {
+		_, err := svc.GetUserByName(ctx, "nonexistent")
+		require.Error(t, err)
 	})
 }
 
 func TestUserService_AddPortfolio(t *testing.T) {
-	// TODO
-	t.Run("should return an error when user dont exist", func(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
 
+	t.Run("should return portfolio name when portfolio is created", func(t *testing.T) {
+		name, err := svc.AddPortfolio(ctx, user.PortfolioIn{
+			UserName: testUser.Username,
+			Name:     "myportfolio",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "myportfolio", name)
+	})
+
+	t.Run("should return error when portfolio name is invalid", func(t *testing.T) {
+		_, err := svc.AddPortfolio(ctx, user.PortfolioIn{
+			UserName: testUser.Username,
+			Name:     "invalid name!",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when user does not exist", func(t *testing.T) {
+		_, err := svc.AddPortfolio(ctx, user.PortfolioIn{
+			UserName: "nonexistent",
+			Name:     "portfolio",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when portfolio with same name already exists", func(t *testing.T) {
+		_, err := svc.AddPortfolio(ctx, user.PortfolioIn{
+			UserName: testUser.Username,
+			Name:     "myportfolio",
+		})
+		require.Error(t, err)
+	})
+}
+
+func TestUserService_AddTransaction(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+
+	_, err = svc.AddPortfolio(ctx, user.PortfolioIn{
+		UserName: testUser.Username,
+		Name:     "myportfolio",
+	})
+	require.NoError(t, err)
+
+	t.Run("should return id when transaction is added", func(t *testing.T) {
+		id, err := svc.AddTransaction(ctx, user.TransactionIn{
+			UserName:      testUser.Username,
+			PortfolioName: "myportfolio",
+			Symbol:        "AAPL",
+			Amount:        "150.00",
+			Quantity:      "2",
+		})
+		require.NoError(t, err)
+		assert.NotEmpty(t, id)
+	})
+
+	t.Run("should return error when portfolio does not exist", func(t *testing.T) {
+		_, err := svc.AddTransaction(ctx, user.TransactionIn{
+			UserName:      testUser.Username,
+			PortfolioName: "nonexistent",
+			Symbol:        "AAPL",
+			Amount:        "150.00",
+			Quantity:      "2",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when symbol is empty", func(t *testing.T) {
+		_, err := svc.AddTransaction(ctx, user.TransactionIn{
+			UserName:      testUser.Username,
+			PortfolioName: "myportfolio",
+			Symbol:        "",
+			Amount:        "150.00",
+			Quantity:      "2",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when quantity is zero", func(t *testing.T) {
+		_, err := svc.AddTransaction(ctx, user.TransactionIn{
+			UserName:      testUser.Username,
+			PortfolioName: "myportfolio",
+			Symbol:        "AAPL",
+			Amount:        "150.00",
+			Quantity:      "0",
+		})
+		require.Error(t, err)
+	})
+
+	t.Run("should update portfolio TotalCost after transaction", func(t *testing.T) {
+		db := fake.NewDatabase()
+		svc := user.Users{
+			Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+			Database:     &db,
+			NewAggregate: user.User.NewAggregate,
+		}
+		_, err := svc.SignUp(ctx, user.User(testUser))
+		require.NoError(t, err)
+		_, err = svc.AddPortfolio(ctx, user.PortfolioIn{UserName: testUser.Username, Name: "tech"})
+		require.NoError(t, err)
+
+		_, err = svc.AddTransaction(ctx, user.TransactionIn{
+			UserName:      testUser.Username,
+			PortfolioName: "tech",
+			Symbol:        "AAPL",
+			Amount:        "150.00",
+			Quantity:      "2",
+		})
+		require.NoError(t, err)
+
+		response, err := svc.GetUserByName(ctx, testUser.Username)
+		require.NoError(t, err)
+		var found bool
+		for _, p := range response.Portfolio {
+			if p.Name == "tech" {
+				found = true
+				assert.True(t, p.TotalCost.Equal(shopspring.NewFromFloat(300.00)))
+			}
+		}
+		require.True(t, found, "portfolio 'tech' not found in response")
+	})
+}
+
+func TestUserService_GetTransactions(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+	_, err = svc.AddPortfolio(ctx, user.PortfolioIn{UserName: testUser.Username, Name: "tech"})
+	require.NoError(t, err)
+	_, err = svc.AddTransaction(ctx, user.TransactionIn{
+		UserName: testUser.Username, PortfolioName: "tech",
+		Symbol: "AAPL", Amount: "150.00", Quantity: "2", Type: "buy",
+	})
+	require.NoError(t, err)
+
+	t.Run("should return transactions for portfolio", func(t *testing.T) {
+		out, err := svc.GetTransactions(ctx, testUser.Username, "tech")
+		require.NoError(t, err)
+		assert.Len(t, out.Transactions, 1)
+		assert.Equal(t, "AAPL", out.Transactions[0].Symbol)
+	})
+
+	t.Run("should return empty list when portfolio has no transactions", func(t *testing.T) {
+		_, err = svc.AddPortfolio(ctx, user.PortfolioIn{UserName: testUser.Username, Name: "empty"})
+		require.NoError(t, err)
+		out, err := svc.GetTransactions(ctx, testUser.Username, "empty")
+		require.NoError(t, err)
+		assert.Empty(t, out.Transactions)
+	})
+}
+
+func TestUserService_AddTransaction_BuyIncreasesTotalCost(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+	_, err = svc.AddPortfolio(ctx, user.PortfolioIn{UserName: testUser.Username, Name: "tech"})
+	require.NoError(t, err)
+
+	_, err = svc.AddTransaction(ctx, user.TransactionIn{
+		UserName: testUser.Username, PortfolioName: "tech",
+		Symbol: "AAPL", Amount: "100.00", Quantity: "3", Type: "buy",
+	})
+	require.NoError(t, err)
+
+	_, err = svc.AddTransaction(ctx, user.TransactionIn{
+		UserName: testUser.Username, PortfolioName: "tech",
+		Symbol: "AAPL", Amount: "100.00", Quantity: "1", Type: "sell",
+	})
+	require.NoError(t, err)
+
+	response, err := svc.GetUserByName(ctx, testUser.Username)
+	require.NoError(t, err)
+	for _, p := range response.Portfolio {
+		if p.Name == "tech" {
+			// buy 3x100 = 300, sell 1x100 = -100 => 200
+			assert.True(t, p.TotalCost.Equal(shopspring.NewFromFloat(200.00)))
+		}
+	}
+}
+
+func TestUserService_UpdateUser(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+
+	t.Run("should update username", func(t *testing.T) {
+		newName, err := svc.UpdateUser(ctx, testUser.Username, user.UpdateUserIn{
+			Username: "newusername",
+		})
+		require.NoError(t, err)
+		assert.Equal(t, "newusername", newName)
+
+		_, err = svc.GetUserByName(ctx, "newusername")
+		require.NoError(t, err)
+	})
+
+	t.Run("should update email", func(t *testing.T) {
+		_, err := svc.UpdateUser(ctx, "newusername", user.UpdateUserIn{
+			Email: "new@test.com",
+		})
+		require.NoError(t, err)
+
+		response, err := svc.GetUserByName(ctx, "newusername")
+		require.NoError(t, err)
+		assert.Equal(t, "new@test.com", response.Email)
+	})
+
+	t.Run("should return error when user does not exist", func(t *testing.T) {
+		_, err := svc.UpdateUser(ctx, "nonexistent", user.UpdateUserIn{Username: "x"})
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when new username is too short", func(t *testing.T) {
+		_, err := svc.UpdateUser(ctx, "newusername", user.UpdateUserIn{Username: "x"})
+		require.Error(t, err)
+	})
+}
+
+func TestUserService_DeleteUser(t *testing.T) {
+	db := fake.NewDatabase()
+	svc := user.Users{
+		Logger:       log.New(os.Stdout, "logger", log.LstdFlags),
+		Database:     &db,
+		NewAggregate: user.User.NewAggregate,
+	}
+	_, err := svc.SignUp(ctx, user.User(testUser))
+	require.NoError(t, err)
+
+	t.Run("should delete existing user", func(t *testing.T) {
+		err := svc.DeleteUser(ctx, testUser.Username)
+		require.NoError(t, err)
+
+		_, err = svc.GetUserByName(ctx, testUser.Username)
+		require.Error(t, err)
+	})
+
+	t.Run("should return error when user does not exist", func(t *testing.T) {
+		err := svc.DeleteUser(ctx, "nonexistent")
+		require.Error(t, err)
 	})
 }
 

--- a/user/user.go
+++ b/user/user.go
@@ -1,11 +1,13 @@
 package user
 
 import (
-	"github.com/szucik/trade-helper/apperrors"
 	"regexp"
 	"time"
 
+	"github.com/shopspring/decimal"
+	"github.com/szucik/trade-helper/apperrors"
 	"github.com/szucik/trade-helper/portfolio"
+	"github.com/szucik/trade-helper/transaction"
 )
 
 type User struct {
@@ -18,15 +20,39 @@ type User struct {
 }
 
 type AuthCredentials struct {
-	Email    string `json:"email" validate:"required"`
+	Email    string `json:"email"    validate:"required"`
 	Password string `json:"password" validate:"required"`
 }
 
+type UpdateUserIn struct {
+	Username string `json:"username"`
+	Email    string `json:"email"`
+	Password string `json:"password"`
+}
+
 type UserResponse struct {
-	Username  string                `json:"username" validate:"required"`
-	Email     string                `json:"email" validate:"required"`
-	Portfolio []portfolio.Portfolio `json:"portfolios" validate:"required"`
+	Username  string                `json:"username"`
+	Email     string                `json:"email"`
+	Portfolio []portfolio.Portfolio `json:"portfolios"`
 	Created   time.Time             `json:"created"`
+}
+
+type TransactionResponse struct {
+	ID            string                   `json:"id"`
+	Symbol        string                   `json:"symbol"`
+	Type          transaction.TransactionType `json:"type"`
+	Quantity      decimal.Decimal          `json:"quantity"`
+	Price         decimal.Decimal          `json:"price"`
+	Created       time.Time                `json:"created"`
+}
+
+type TransactionsOut struct {
+	Transactions []TransactionResponse `json:"transactions"`
+}
+
+type PaginationIn struct {
+	Page  int
+	Limit int
 }
 
 func (u User) NewAggregate() (Aggregate, error) {
@@ -60,10 +86,7 @@ func (u User) NewAggregate() (Aggregate, error) {
 }
 
 func isLengthValid(value string, length int) bool {
-	if len(value) < length {
-		return false
-	}
-	return true
+	return len(value) >= length
 }
 
 func isEmailValid(email string) bool {

--- a/user/user_test.go
+++ b/user/user_test.go
@@ -29,6 +29,12 @@ func TestUser_NewAggregate(t *testing.T) {
 			"password has less than 8 characters": {
 				user: testUser.WithPassword("1234567"),
 			},
+			"username has less than 2 characters": {
+				user: testUser.WithName("a"),
+			},
+			"username is empty": {
+				user: testUser.WithName(""),
+			},
 		}
 
 		for name, testCase := range testCases {

--- a/web/handlers/handlers_test.go
+++ b/web/handlers/handlers_test.go
@@ -1,0 +1,372 @@
+package handlers_test
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/gorilla/mux"
+	"github.com/gorilla/sessions"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/szucik/trade-helper/apperrors"
+	"github.com/szucik/trade-helper/user"
+	"github.com/szucik/trade-helper/web/handlers"
+)
+
+var testStore = sessions.NewCookieStore([]byte("test-secret"))
+
+type fakeService struct {
+	signUpFn         func(ctx context.Context, u user.User) (string, error)
+	signInFn         func(ctx context.Context, c user.AuthCredentials) (string, error)
+	getUsersFn       func(ctx context.Context, p user.PaginationIn) (user.UsersOut, error)
+	getUserByNameFn  func(ctx context.Context, name string) (user.UserResponse, error)
+	addPortfolioFn   func(ctx context.Context, in user.PortfolioIn) (string, error)
+	addTransactionFn func(ctx context.Context, in user.TransactionIn) (string, error)
+	getTransactionsFn func(ctx context.Context, username, portfolioName string) (user.TransactionsOut, error)
+	updateUserFn     func(ctx context.Context, username string, in user.UpdateUserIn) (string, error)
+	deleteUserFn     func(ctx context.Context, username string) error
+}
+
+func (f *fakeService) SignUp(ctx context.Context, u user.User) (string, error) {
+	return f.signUpFn(ctx, u)
+}
+func (f *fakeService) SignIn(ctx context.Context, c user.AuthCredentials) (string, error) {
+	return f.signInFn(ctx, c)
+}
+func (f *fakeService) GetUsers(ctx context.Context, p user.PaginationIn) (user.UsersOut, error) {
+	return f.getUsersFn(ctx, p)
+}
+func (f *fakeService) GetUserByEmail(_ context.Context, _ string) (user.UserResponse, error) {
+	return user.UserResponse{}, nil
+}
+func (f *fakeService) GetUserByName(ctx context.Context, name string) (user.UserResponse, error) {
+	return f.getUserByNameFn(ctx, name)
+}
+func (f *fakeService) AddPortfolio(ctx context.Context, in user.PortfolioIn) (string, error) {
+	return f.addPortfolioFn(ctx, in)
+}
+func (f *fakeService) AddTransaction(ctx context.Context, in user.TransactionIn) (string, error) {
+	return f.addTransactionFn(ctx, in)
+}
+func (f *fakeService) GetTransactions(ctx context.Context, username, portfolioName string) (user.TransactionsOut, error) {
+	return f.getTransactionsFn(ctx, username, portfolioName)
+}
+func (f *fakeService) UpdateUser(ctx context.Context, username string, in user.UpdateUserIn) (string, error) {
+	return f.updateUserFn(ctx, username, in)
+}
+func (f *fakeService) DeleteUser(ctx context.Context, username string) error {
+	return f.deleteUserFn(ctx, username)
+}
+
+func newRequest(t *testing.T, method, path string, body any) *http.Request {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		require.NoError(t, json.NewEncoder(&buf).Encode(body))
+	}
+	r, err := http.NewRequest(method, path, &buf)
+	require.NoError(t, err)
+	return r
+}
+
+func withVars(r *http.Request, vars map[string]string) *http.Request {
+	return mux.SetURLVars(r, vars)
+}
+
+// --- SignUp ---
+
+func TestSignUp_ReturnsUsername_WhenInputIsValid(t *testing.T) {
+	svc := &fakeService{
+		signUpFn: func(_ context.Context, u user.User) (string, error) { return u.Username, nil },
+	}
+	r := newRequest(t, http.MethodPost, "/signup", user.User{
+		Username: "alice", Email: "alice@test.com", Password: "secret123",
+	})
+	rw := httptest.NewRecorder()
+	handlers.SignUp(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Contains(t, rw.Body.String(), "alice")
+}
+
+func TestSignUp_Returns400_WhenRequiredFieldsMissing(t *testing.T) {
+	svc := &fakeService{}
+	r := newRequest(t, http.MethodPost, "/signup", user.User{Username: "alice"})
+	rw := httptest.NewRecorder()
+	handlers.SignUp(svc)(rw, r)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+func TestSignUp_Returns400_WhenBodyIsInvalid(t *testing.T) {
+	svc := &fakeService{}
+	r, _ := http.NewRequest(http.MethodPost, "/signup", bytes.NewBufferString("not-json"))
+	rw := httptest.NewRecorder()
+	handlers.SignUp(svc)(rw, r)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+func TestSignUp_Returns409_WhenUserAlreadyExists(t *testing.T) {
+	svc := &fakeService{
+		signUpFn: func(_ context.Context, _ user.User) (string, error) {
+			return "", apperrors.Error("user already exists", "DuplicateUser", http.StatusConflict)
+		},
+	}
+	r := newRequest(t, http.MethodPost, "/signup", user.User{
+		Username: "alice", Email: "alice@test.com", Password: "secret123",
+	})
+	rw := httptest.NewRecorder()
+	handlers.SignUp(svc)(rw, r)
+
+	assert.Equal(t, http.StatusConflict, rw.Code)
+}
+
+// --- SignIn ---
+
+func TestSignIn_ReturnsUsername_WhenCredentialsAreValid(t *testing.T) {
+	svc := &fakeService{
+		signInFn: func(_ context.Context, _ user.AuthCredentials) (string, error) { return "alice", nil },
+	}
+	r := newRequest(t, http.MethodPost, "/signin", user.AuthCredentials{
+		Email: "alice@test.com", Password: "secret123",
+	})
+	rw := httptest.NewRecorder()
+	handlers.SignIn(svc, testStore)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Contains(t, rw.Body.String(), "alice")
+}
+
+func TestSignIn_Returns400_WhenCredentialsAreWrong(t *testing.T) {
+	svc := &fakeService{
+		signInFn: func(_ context.Context, _ user.AuthCredentials) (string, error) {
+			return "", errors.New("invalid password")
+		},
+	}
+	r := newRequest(t, http.MethodPost, "/signin", user.AuthCredentials{
+		Email: "alice@test.com", Password: "wrong",
+	})
+	rw := httptest.NewRecorder()
+	handlers.SignIn(svc, testStore)(rw, r)
+
+	assert.Equal(t, http.StatusInternalServerError, rw.Code)
+}
+
+func TestSignIn_Returns400_WhenRequiredFieldsMissing(t *testing.T) {
+	svc := &fakeService{}
+	r := newRequest(t, http.MethodPost, "/signin", user.AuthCredentials{Email: "alice@test.com"})
+	rw := httptest.NewRecorder()
+	handlers.SignIn(svc, testStore)(rw, r)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+// --- GetUsers ---
+
+func TestGetUsers_ReturnsUserList(t *testing.T) {
+	svc := &fakeService{
+		getUsersFn: func(_ context.Context, _ user.PaginationIn) (user.UsersOut, error) {
+			return user.UsersOut{
+				Users: []user.UserResponse{{Username: "alice"}, {Username: "bob"}},
+				Total: 2,
+			}, nil
+		},
+	}
+	r, _ := http.NewRequest(http.MethodGet, "/users", nil)
+	rw := httptest.NewRecorder()
+	handlers.GetUsers(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	var out user.UsersOut
+	require.NoError(t, json.NewDecoder(rw.Body).Decode(&out))
+	assert.Len(t, out.Users, 2)
+}
+
+func TestGetUsers_PassesPaginationParams(t *testing.T) {
+	var capturedPagination user.PaginationIn
+	svc := &fakeService{
+		getUsersFn: func(_ context.Context, p user.PaginationIn) (user.UsersOut, error) {
+			capturedPagination = p
+			return user.UsersOut{}, nil
+		},
+	}
+	r, _ := http.NewRequest(http.MethodGet, "/users?page=2&limit=10", nil)
+	rw := httptest.NewRecorder()
+	handlers.GetUsers(svc)(rw, r)
+
+	assert.Equal(t, 2, capturedPagination.Page)
+	assert.Equal(t, 10, capturedPagination.Limit)
+}
+
+// --- GetUser ---
+
+func TestGetUser_ReturnsUser_WhenUsernameExists(t *testing.T) {
+	svc := &fakeService{
+		getUserByNameFn: func(_ context.Context, name string) (user.UserResponse, error) {
+			return user.UserResponse{Username: name, Email: "alice@test.com"}, nil
+		},
+	}
+	r := withVars(newRequest(t, http.MethodGet, "/users/alice", nil), map[string]string{"username": "alice"})
+	rw := httptest.NewRecorder()
+	handlers.GetUser(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	var out user.UserResponse
+	require.NoError(t, json.NewDecoder(rw.Body).Decode(&out))
+	assert.Equal(t, "alice", out.Username)
+}
+
+func TestGetUser_Returns404_WhenUsernameNotFound(t *testing.T) {
+	svc := &fakeService{
+		getUserByNameFn: func(_ context.Context, _ string) (user.UserResponse, error) {
+			return user.UserResponse{}, apperrors.Error("user not found", "UserNotFound", http.StatusNotFound)
+		},
+	}
+	r := withVars(newRequest(t, http.MethodGet, "/users/ghost", nil), map[string]string{"username": "ghost"})
+	rw := httptest.NewRecorder()
+	handlers.GetUser(svc)(rw, r)
+
+	assert.Equal(t, http.StatusNotFound, rw.Code)
+}
+
+// --- AddPortfolio ---
+
+func TestAddPortfolio_ReturnsName_WhenInputIsValid(t *testing.T) {
+	svc := &fakeService{
+		addPortfolioFn: func(_ context.Context, in user.PortfolioIn) (string, error) { return in.Name, nil },
+	}
+	r := withVars(
+		newRequest(t, http.MethodPost, "/users/alice/portfolio", map[string]string{"Name": "tech"}),
+		map[string]string{"username": "alice"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.AddPortfolio(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+}
+
+func TestAddPortfolio_Returns400_WhenNameMissing(t *testing.T) {
+	svc := &fakeService{}
+	r := withVars(
+		newRequest(t, http.MethodPost, "/users/alice/portfolio", map[string]string{}),
+		map[string]string{"username": "alice"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.AddPortfolio(svc)(rw, r)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+// --- AddTransaction ---
+
+func TestAddTransaction_ReturnsID_WhenInputIsValid(t *testing.T) {
+	svc := &fakeService{
+		addTransactionFn: func(_ context.Context, _ user.TransactionIn) (string, error) { return "txn-id-123", nil },
+	}
+	r := withVars(
+		newRequest(t, http.MethodPost, "/users/alice/portfolio/tech/transactions", user.TransactionIn{
+			Symbol: "AAPL", Amount: "150.00", Quantity: "2",
+		}),
+		map[string]string{"username": "alice", "name": "tech"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.AddTransaction(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Contains(t, rw.Body.String(), "txn-id-123")
+}
+
+func TestAddTransaction_Returns400_WhenRequiredFieldsMissing(t *testing.T) {
+	svc := &fakeService{}
+	r := withVars(
+		newRequest(t, http.MethodPost, "/users/alice/portfolio/tech/transactions", user.TransactionIn{Symbol: "AAPL"}),
+		map[string]string{"username": "alice", "name": "tech"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.AddTransaction(svc)(rw, r)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+// --- GetTransactions ---
+
+func TestGetTransactions_ReturnsList(t *testing.T) {
+	svc := &fakeService{
+		getTransactionsFn: func(_ context.Context, _, _ string) (user.TransactionsOut, error) {
+			return user.TransactionsOut{Transactions: []user.TransactionResponse{{Symbol: "AAPL"}}}, nil
+		},
+	}
+	r := withVars(
+		newRequest(t, http.MethodGet, "/users/alice/portfolio/tech/transactions", nil),
+		map[string]string{"username": "alice", "name": "tech"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.GetTransactions(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	var out user.TransactionsOut
+	require.NoError(t, json.NewDecoder(rw.Body).Decode(&out))
+	assert.Len(t, out.Transactions, 1)
+}
+
+// --- UpdateUser ---
+
+func TestUpdateUser_ReturnsNewUsername_WhenInputIsValid(t *testing.T) {
+	svc := &fakeService{
+		updateUserFn: func(_ context.Context, _ string, in user.UpdateUserIn) (string, error) { return in.Username, nil },
+	}
+	r := withVars(
+		newRequest(t, http.MethodPut, "/users/alice", user.UpdateUserIn{Username: "alice2"}),
+		map[string]string{"username": "alice"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.UpdateUser(svc)(rw, r)
+
+	assert.Equal(t, http.StatusOK, rw.Code)
+	assert.Contains(t, rw.Body.String(), "alice2")
+}
+
+func TestUpdateUser_Returns400_WhenAllFieldsEmpty(t *testing.T) {
+	svc := &fakeService{}
+	r := withVars(
+		newRequest(t, http.MethodPut, "/users/alice", user.UpdateUserIn{}),
+		map[string]string{"username": "alice"},
+	)
+	rw := httptest.NewRecorder()
+	handlers.UpdateUser(svc)(rw, r)
+
+	assert.Equal(t, http.StatusBadRequest, rw.Code)
+}
+
+// --- DeleteUser ---
+
+func TestDeleteUser_Returns204_WhenUserExists(t *testing.T) {
+	svc := &fakeService{
+		deleteUserFn: func(_ context.Context, _ string) error { return nil },
+	}
+	r := withVars(newRequest(t, http.MethodDelete, "/users/alice", nil), map[string]string{"username": "alice"})
+	rw := httptest.NewRecorder()
+	handlers.DeleteUser(svc)(rw, r)
+
+	assert.Equal(t, http.StatusNoContent, rw.Code)
+}
+
+func TestDeleteUser_Returns404_WhenUserNotFound(t *testing.T) {
+	svc := &fakeService{
+		deleteUserFn: func(_ context.Context, _ string) error {
+			return apperrors.Error("user not found", "UserNotFound", http.StatusNotFound)
+		},
+	}
+	r := withVars(newRequest(t, http.MethodDelete, "/users/ghost", nil), map[string]string{"username": "ghost"})
+	rw := httptest.NewRecorder()
+	handlers.DeleteUser(svc)(rw, r)
+
+	assert.Equal(t, http.StatusNotFound, rw.Code)
+}

--- a/web/handlers/portfolio.go
+++ b/web/handlers/portfolio.go
@@ -1,30 +1,33 @@
 package handlers
 
 import (
-	"context"
 	"encoding/json"
 	"net/http"
 
 	"github.com/gorilla/mux"
 
+	"github.com/szucik/trade-helper/apperrors"
 	"github.com/szucik/trade-helper/user"
 )
 
-func AddPortfolio(ctx context.Context, service user.UsersService) func(http.ResponseWriter, *http.Request) {
+func AddPortfolio(service user.UsersService) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		var p user.PortfolioIn
-		username := mux.Vars(r)["username"]
 
-		err := json.NewDecoder(r.Body).Decode(&p)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "BadRequest", http.StatusBadRequest))
 			return
 		}
 
-		p.UserName = username
-		name, err := service.AddPortfolio(ctx, p)
+		if p.Name == "" {
+			writeError(rw, apperrors.Error("portfolio name is required", "ValidationError", http.StatusBadRequest))
+			return
+		}
+
+		p.UserName = mux.Vars(r)["username"]
+		name, err := service.AddPortfolio(r.Context(), p)
 		if err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+			writeError(rw, err)
 			return
 		}
 
@@ -32,26 +35,52 @@ func AddPortfolio(ctx context.Context, service user.UsersService) func(http.Resp
 	}
 }
 
-func AddTransaction(ctx context.Context, service user.UsersService) func(http.ResponseWriter, *http.Request) {
+func AddTransaction(service user.UsersService) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		var p user.TransactionIn
 		vars := mux.Vars(r)
 
-		err := json.NewDecoder(r.Body).Decode(&p)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+		if err := json.NewDecoder(r.Body).Decode(&p); err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "BadRequest", http.StatusBadRequest))
+			return
+		}
+
+		if p.Symbol == "" || p.Amount == "" || p.Quantity == "" {
+			writeError(rw, apperrors.Error("symbol, amount and quantity are required", "ValidationError", http.StatusBadRequest))
 			return
 		}
 
 		p.UserName = vars["username"]
 		p.PortfolioName = vars["name"]
 
-		result, err := service.AddTransaction(ctx, p)
+		result, err := service.AddTransaction(r.Context(), p)
 		if err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+			writeError(rw, err)
 			return
 		}
 
 		writeSuccessMessage(rw, []byte(result))
+	}
+}
+
+func GetTransactions(service user.UsersService) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+		username := vars["username"]
+		portfolioName := vars["name"]
+
+		out, err := service.GetTransactions(r.Context(), username, portfolioName)
+		if err != nil {
+			writeError(rw, err)
+			return
+		}
+
+		result, err := json.Marshal(out)
+		if err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "MarshalError", http.StatusInternalServerError))
+			return
+		}
+
+		writeSuccessMessage(rw, result)
 	}
 }

--- a/web/handlers/user.go
+++ b/web/handlers/user.go
@@ -2,31 +2,33 @@ package handlers
 
 import (
 	"encoding/json"
-	"fmt"
+	"errors"
+	"net/http"
+	"strconv"
+
 	"github.com/gorilla/mux"
 	"github.com/gorilla/sessions"
-	"net/http"
 
+	"github.com/szucik/trade-helper/apperrors"
 	"github.com/szucik/trade-helper/user"
 )
 
-var store = sessions.NewCookieStore([]byte("something-very-secret"))
-
 func SignUp(service user.UsersService) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		var user user.User
-
-		err := json.NewDecoder(r.Body).Decode(&user)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+		var u user.User
+		if err := json.NewDecoder(r.Body).Decode(&u); err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "BadRequest", http.StatusBadRequest))
 			return
 		}
 
-		username, err := service.SignUp(r.Context(), user)
+		if u.Username == "" || u.Email == "" || u.Password == "" {
+			writeError(rw, apperrors.Error("username, email and password are required", "ValidationError", http.StatusBadRequest))
+			return
+		}
 
+		username, err := service.SignUp(r.Context(), u)
 		if err != nil {
-			//TODO - handle errors, or logger
-			http.Error(rw, err.Error(), 400)
+			writeError(rw, err)
 			return
 		}
 
@@ -34,47 +36,58 @@ func SignUp(service user.UsersService) func(http.ResponseWriter, *http.Request) 
 	}
 }
 
-func SignIn(service user.UsersService) func(http.ResponseWriter, *http.Request) {
+func SignIn(service user.UsersService, store *sessions.CookieStore) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
 		var credentials user.AuthCredentials
-		err := json.NewDecoder(r.Body).Decode(&credentials)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusBadRequest)
+		if err := json.NewDecoder(r.Body).Decode(&credentials); err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "BadRequest", http.StatusBadRequest))
+			return
+		}
+
+		if credentials.Email == "" || credentials.Password == "" {
+			writeError(rw, apperrors.Error("email and password are required", "ValidationError", http.StatusBadRequest))
 			return
 		}
 
 		username, err := service.SignIn(r.Context(), credentials)
 		if err != nil {
-			http.Error(rw, err.Error(), 400)
+			writeError(rw, err)
 			return
 		}
+
 		session, _ := store.Get(r, "X-Auth")
 		session.Options = &sessions.Options{
 			Path:     "/",
 			MaxAge:   86400 * 7,
 			HttpOnly: true,
 		}
+		session.Values["username"] = username
 
-		err = session.Save(r, rw)
-		if err != nil {
-			http.Error(rw, err.Error(), http.StatusInternalServerError)
+		if err = session.Save(r, rw); err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "SessionError", http.StatusInternalServerError))
 			return
 		}
+
 		writeSuccessMessage(rw, []byte(username))
 	}
 }
 
 func GetUsers(service user.UsersService) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		users, err := service.GetUsers(r.Context())
+		p := user.PaginationIn{
+			Page:  queryInt(r, "page", 0),
+			Limit: queryInt(r, "limit", 0),
+		}
+
+		out, err := service.GetUsers(r.Context(), p)
 		if err != nil {
-			http.Error(rw, err.Error(), 400)
+			writeError(rw, err)
 			return
 		}
 
-		result, err := json.Marshal(users)
+		result, err := json.Marshal(out)
 		if err != nil {
-			fmt.Printf("could not marshal json: %s\n", err)
+			writeError(rw, apperrors.Error(err.Error(), "MarshalError", http.StatusInternalServerError))
 			return
 		}
 
@@ -84,17 +97,15 @@ func GetUsers(service user.UsersService) func(http.ResponseWriter, *http.Request
 
 func GetUser(service user.UsersService) func(http.ResponseWriter, *http.Request) {
 	return func(rw http.ResponseWriter, r *http.Request) {
-		vars := mux.Vars(r)
-		user, err := service.GetUserByName(r.Context(), vars["username"])
+		u, err := service.GetUserByName(r.Context(), mux.Vars(r)["username"])
 		if err != nil {
-			fmt.Errorf("%s", err.Error())
+			writeError(rw, err)
 			return
 		}
 
-		rw.WriteHeader(http.StatusOK)
-		result, err := json.Marshal(user)
+		result, err := json.Marshal(u)
 		if err != nil {
-			fmt.Printf("could not marshal json: %s\n", err)
+			writeError(rw, apperrors.Error(err.Error(), "MarshalError", http.StatusInternalServerError))
 			return
 		}
 
@@ -102,7 +113,65 @@ func GetUser(service user.UsersService) func(http.ResponseWriter, *http.Request)
 	}
 }
 
+func UpdateUser(service user.UsersService) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		var in user.UpdateUserIn
+		if err := json.NewDecoder(r.Body).Decode(&in); err != nil {
+			writeError(rw, apperrors.Error(err.Error(), "BadRequest", http.StatusBadRequest))
+			return
+		}
+
+		if in.Username == "" && in.Email == "" && in.Password == "" {
+			writeError(rw, apperrors.Error("at least one field is required", "ValidationError", http.StatusBadRequest))
+			return
+		}
+
+		username := mux.Vars(r)["username"]
+		updated, err := service.UpdateUser(r.Context(), username, in)
+		if err != nil {
+			writeError(rw, err)
+			return
+		}
+
+		writeSuccessMessage(rw, []byte(updated))
+	}
+}
+
+func DeleteUser(service user.UsersService) func(http.ResponseWriter, *http.Request) {
+	return func(rw http.ResponseWriter, r *http.Request) {
+		username := mux.Vars(r)["username"]
+		if err := service.DeleteUser(r.Context(), username); err != nil {
+			writeError(rw, err)
+			return
+		}
+
+		rw.WriteHeader(http.StatusNoContent)
+	}
+}
+
+func writeError(rw http.ResponseWriter, err error) {
+	var appErr apperrors.ErrorResponse
+	if errors.As(err, &appErr) {
+		appErr.JSONError(rw)
+		return
+	}
+	http.Error(rw, err.Error(), http.StatusInternalServerError)
+}
+
 func writeSuccessMessage(rw http.ResponseWriter, result []byte) {
+	rw.Header().Set("Content-Type", "application/json")
 	rw.WriteHeader(http.StatusOK)
 	rw.Write(result)
+}
+
+func queryInt(r *http.Request, key string, def int) int {
+	s := r.URL.Query().Get(key)
+	if s == "" {
+		return def
+	}
+	v, err := strconv.Atoi(s)
+	if err != nil {
+		return def
+	}
+	return v
 }

--- a/web/middleware.go
+++ b/web/middleware.go
@@ -3,26 +3,26 @@ package web
 import (
 	"net/http"
 
+	"github.com/gorilla/sessions"
+
 	"github.com/szucik/trade-helper/apperrors"
-	_ "github.com/szucik/trade-helper/portfolio"
 )
 
-func MiddlewareIsAuth(next http.Handler) http.Handler {
-	return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
-		if r.RequestURI != "/signup" && r.RequestURI != "/signin" {
-			_, err := r.Cookie("X-Auth")
-			if err != nil {
-				if err == http.ErrNoCookie {
-					apperrors.Error("Invalid user", "BadRequest", 400).JSONError(rw)
-					rw.WriteHeader(http.StatusUnauthorized)
-					return
-				}
-				rw.WriteHeader(http.StatusBadRequest)
-				apperrors.Error("Bad data", "BadRequest", 400).JSONError(rw)
+func MiddlewareIsAuth(store *sessions.CookieStore) func(http.Handler) http.Handler {
+	return func(next http.Handler) http.Handler {
+		return http.HandlerFunc(func(rw http.ResponseWriter, r *http.Request) {
+			if r.RequestURI == "/signup" || r.RequestURI == "/signin" {
+				next.ServeHTTP(rw, r)
 				return
 			}
-		}
 
-		next.ServeHTTP(rw, r)
-	})
+			session, err := store.Get(r, "X-Auth")
+			if err != nil || session.Values["username"] == nil {
+				apperrors.Error("unauthorized", "Unauthorized", http.StatusUnauthorized).JSONError(rw)
+				return
+			}
+
+			next.ServeHTTP(rw, r)
+		})
+	}
 }


### PR DESCRIPTION
  - Require SESSION_SECRET env var on startup (fail-fast, no insecure fallback)
  - Wire gorilla/sessions store into SignIn and auth middleware
  - Add UpdateUser and DeleteUser service methods and HTTP handlers
  - Add GetTransactions endpoint and service method
  - Add pagination support (page/limit) to GetUsers
  - Add TransactionType (buy/sell) to TransactionIn
  - Complete fake and mongo repository implementations for all new methods
  - Add handler tests covering signup, signin, portfolio and transaction flows
  - Fix route regex patterns ([a-z, A-Z, 0-9] → [a-zA-Z0-9])
  - Improve graceful shutdown with separate context and SIGTERM handling